### PR TITLE
Hardcode setup.py requirements to avoid use pip internals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - "export DISPLAY=:99.0"
 
 script:
-- pytest --cov-config .coveragerc --cov=scrapy_selenium tests/
+- python setup.py test
 - codeclimate-test-reporter
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ python:
 addons:
   firefox: "49.0.2"
 
-install:
-- pip install -r requirements/requirements-test.txt
-
 before_script:
   - wget https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz
   - mkdir geckodriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ services:
 
 env:
   global:
-  - CODECLIMATE_REPO_TOKEN=a47935830d841ad61a6e960be8a3b6a5e557146ac010dafa993e61bf82898472
+    - CODECLIMATE_REPO_TOKEN=a47935830d841ad61a6e960be8a3b6a5e557146ac010dafa993e61bf82898472
 
 language: python
 
 python:
-- 3.6
+  - 3.6
 
 addons:
   firefox: "49.0.2"
@@ -20,10 +20,15 @@ before_script:
   - tar -xzf geckodriver-v0.11.1-linux64.tar.gz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver
   - "export DISPLAY=:99.0"
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 
 script:
-- python setup.py test
-- codeclimate-test-reporter
+  - python setup.py test
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 
 env:
   global:
-    - CODECLIMATE_REPO_TOKEN=a47935830d841ad61a6e960be8a3b6a5e557146ac010dafa993e61bf82898472
+    - CC_TEST_REPORTER_ID=a47935830d841ad61a6e960be8a3b6a5e557146ac010dafa993e61bf82898472
 
 language: python
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include requirements/requirements.txt

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,7 +1,0 @@
--r requirements.txt
-
-pytest==3.4.0
-coverage<4.4
-pytest-cov==2.4.0
-codeclimate-test-reporter==0.2.3
-attrs>=17.4.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,0 @@
-scrapy>=1.0.0
-selenium>=3.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,9 @@ include_package_data = true
 
 [pep8]
 max-line-length = 100
+
+[aliases]
+test=pytest
+
+[tool:pytest]
+addopts = --cov-config .coveragerc --cov=scrapy_selenium tests/

--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,21 @@
 """This module contains the packaging routine for the pybook package"""
 
 from setuptools import setup, find_packages
-try:
-    from pip.download import PipSession
-    from pip.req import parse_requirements
-except ImportError:
-    # It is quick hack to support pip 10 that has changed its internal
-    # structure of the modules.
-    from pip._internal.download import PipSession
-    from pip._internal.req.req_file import parse_requirements
 
+requirements = [
+    "scrapy>=1.0.0",
+    "selenium>=3.9.0",
+]
 
-def get_requirements(source):
-    """Get the requirements from the given ``source``
-
-    Parameters
-    ----------
-    source: str
-        The filename containing the requirements
-
-    """
-
-    install_reqs = parse_requirements(filename=source, session=PipSession())
-
-    return [str(ir.req) for ir in install_reqs]
-
+test_requirements = [
+    "pytest==3.4.0",
+    "coverage<4.4",
+    "pytest-cov==2.4.0",
+    "codeclimate-test-reporter==0.2.3",
+    "attrs>=17.4.0",
+]
 
 setup(
     packages=find_packages(),
-    install_requires=get_requirements('requirements/requirements.txt')
+    install_requires=requirements,
 )
-
-

--- a/setup.py
+++ b/setup.py
@@ -2,20 +2,19 @@
 
 from setuptools import setup, find_packages
 
-requirements = [
-    "scrapy>=1.0.0",
-    "selenium>=3.9.0",
-]
-
-test_requirements = [
-    "pytest==3.4.0",
-    "coverage<4.4",
-    "pytest-cov==2.4.0",
-    "codeclimate-test-reporter==0.2.3",
-    "attrs>=17.4.0",
-]
-
 setup(
     packages=find_packages(),
-    install_requires=requirements,
+    setup_requires=[
+        "pytest-runner",
+    ],
+    install_requires=[
+        "scrapy>=1.0.0",
+        "selenium>=3.9.0",
+    ],
+    tests_require=[
+        "pytest",
+        "coverage",
+        "pytest-cov",
+        "codeclimate-test-reporter",
+    ]
 )


### PR DESCRIPTION
Hi @clemfromspace 

I migrated the requirements files to setup.py and adjusted the tests to be run through `python setup.py test` (even in travis).

I've also updated both test requirements versions and code climate test reporter (once the previous reporter was deprecated).

Fixes #56