### PR TITLE
Handle timeout exception from selenium

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -4,4 +4,4 @@ pytest==3.4.0
 coverage<4.4
 pytest-cov==2.4.0
 codeclimate-test-reporter==0.2.3
-attrs>=17.4.0
+attrs>=17.4.0,<19.0.0

--- a/scrapy_selenium/middlewares.py
+++ b/scrapy_selenium/middlewares.py
@@ -6,6 +6,7 @@ from scrapy import signals
 from scrapy.exceptions import NotConfigured
 from scrapy.http import HtmlResponse
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.common.exceptions import TimeoutException
 
 from .http import SeleniumRequest
 
@@ -111,9 +112,12 @@ class SeleniumMiddleware:
             )
 
         if request.wait_until:
-            WebDriverWait(self.driver, request.wait_time).until(
-                request.wait_until
-            )
+            try:
+                WebDriverWait(self.driver, request.wait_time).until(
+                    request.wait_until
+                )
+            except TimeoutException:
+                pass
 
         if request.screenshot:
             request.meta['screenshot'] = self.driver.get_screenshot_as_png()

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -1,6 +1,6 @@
 """This module contains the test cases for the middlewares of the ``scrapy_selenium`` package"""
 
-from unittest.mock import patch
+from unittest import mock
 
 from scrapy import Request
 from scrapy.crawler import Crawler
@@ -64,7 +64,7 @@ class SeleniumMiddlewareTestCase(BaseScrapySeleniumTestCase):
 
         selenium_middleware = SeleniumMiddleware.from_crawler(crawler)
 
-        with patch.object(selenium_middleware.driver, 'quit') as mocked_quit:
+        with mock.patch.object(selenium_middleware.driver, 'quit') as mocked_quit:
             selenium_middleware.spider_closed()
 
         mocked_quit.assert_called_once()

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -135,3 +135,23 @@ class SeleniumMiddlewareTestCase(BaseScrapySeleniumTestCase):
             html_response.selector.xpath('//title/text()').extract_first(),
             'scrapy_selenium'
         )
+
+    @mock.patch('scrapy_selenium.middlewares.WebDriverWait')
+    def test_process_request_should_use_wait_time_and_wait_until_when_available(self, WebDriverWait):
+        """Test that the ``process_request`` should execute the WebDriverWait from selenium"""
+
+        wait_time = 2
+        wait_until = mock.Mock()  # just a unique value to be checked in mock calling
+        selenium_request = SeleniumRequest(
+            url='http://www.python.org',
+            wait_time=wait_time,
+            wait_until=wait_until,
+        )
+
+        self.selenium_middleware.process_request(
+            request=selenium_request,
+            spider=None
+        )
+
+        WebDriverWait.assert_called_with(self.selenium_middleware.driver, wait_time)
+        WebDriverWait.return_value.until.assert_called_with(wait_until)


### PR DESCRIPTION
Hi @clemfromspace 

I implemented the necessary steps to meet the issue #58. There wasn't any test of the wait_time and wait_until usage, so I added one.

I decided to always ignore the timeout exception and return the content to scrapy, but I can surely add a config option to allow retrocompatibity, if you prefer.