### PR TITLE
Update setup.py to accomodate pip 20+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,18 @@
 """This module contains the packaging routine for the pybook package"""
 
 from setuptools import setup, find_packages
-try:
-    from pip.download import PipSession
-    from pip.req import parse_requirements
-except ImportError:
-    # It is quick hack to support pip 10 that has changed its internal
-    # structure of the modules.
+
+import pip
+pip_major_version = int(pip.__version__.split(".")[0])
+if pip_major_version >= 20:
+    from pip._internal.req import parse_requirements
+    from pip._internal.network.session import PipSession
+elif pip_major_version >= 10:
+    from pip._internal.req import parse_requirements
     from pip._internal.download import PipSession
-    from pip._internal.req.req_file import parse_requirements
+else:
+    from pip.req import parse_requirements
+    from pip.download import PipSession
 
 
 def get_requirements(source):


### PR DESCRIPTION
This fixes a problem with the newest version of pip:

```
Traceback (most recent call last):
  File "scrapy-selenium/setup.py", line 5, in <module>
    from pip.download import PipSession
ModuleNotFoundError: No module named 'pip.download'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "scrapy-selenium/setup.py", line 10, in <module>
    from pip._internal.download import PipSession
ModuleNotFoundError: No module named 'pip._internal.download'
```