### PR TITLE
Save custom attribute like wait_time in SeleniumRequest into Request.meta

### DIFF
--- a/scrapy_selenium/http.py
+++ b/scrapy_selenium/http.py
@@ -24,9 +24,12 @@ class SeleniumRequest(Request):
 
         """
 
-        self.wait_time = wait_time
-        self.wait_until = wait_until
-        self.screenshot = screenshot
-        self.script = script
-
+        meta = {
+            "wait_time": wait_time,
+            "wait_until": wait_until,
+            "screenshot": screenshot,
+            "script": script,
+        }
+        meta.update(kwargs.pop("meta", {}))
+        kwargs["meta"] = meta
         super().__init__(*args, **kwargs)

--- a/scrapy_selenium/middlewares.py
+++ b/scrapy_selenium/middlewares.py
@@ -110,16 +110,16 @@ class SeleniumMiddleware:
                 }
             )
 
-        if request.wait_until:
-            WebDriverWait(self.driver, request.wait_time).until(
-                request.wait_until
+        if request.meta.get('wait_until'):
+            WebDriverWait(self.driver, request.meta.get('wait_time')).until(
+                request.meta.get('wait_until')
             )
 
-        if request.screenshot:
+        if request.meta.get('screenshot'):
             request.meta['screenshot'] = self.driver.get_screenshot_as_png()
 
-        if request.script:
-            self.driver.execute_script(request.script)
+        if request.meta.get('script'):
+            self.driver.execute_script(request.meta.get('script'))
 
         body = str.encode(self.driver.page_source)
 


### PR DESCRIPTION
The canonical way to share info between `Request` and download middleware is `Request.meta`.
Custom attributes `Request.custom_attr` should be avoided, cause it may be dropped
after possible serialization and de-serialization in `Scheduler`.

E.g. `scrapy-redis` converts `Request` into dict with `scrapy.utils.reqpar.request_to_dict()`. Custom attribute on `Request` will be lost.

```python
# scrapy.utils.reqpar
def request_to_dict(request, spider=None):
    """Convert Request object to a dict.

    If a spider is given, it will try to find out the name of the spider method
    used in the callback and store that as the callback.
    """
    cb = request.callback
    if callable(cb):
        cb = _find_method(spider, cb)
    eb = request.errback
    if callable(eb):
        eb = _find_method(spider, eb)
    d = {
        'url': to_unicode(request.url),  # urls should be safe (safe_string_url)
        'callback': cb,
        'errback': eb,
        'method': request.method,
        'headers': dict(request.headers),
        'body': request.body,
        'cookies': request.cookies,
        'meta': request.meta,
        '_encoding': request._encoding,
        'priority': request.priority,
        'dont_filter': request.dont_filter,
        'flags': request.flags,
        'cb_kwargs': request.cb_kwargs,
    }
    if type(request) is not Request:
        d['_class'] = request.__module__ + '.' + request.__class__.__name__
    return d
```