### PR TITLE
Add support for perform selenium action before return the response from middleware .

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,26 @@ yield SeleniumRequest(
     script='window.scrollTo(0, document.body.scrollHeight);',
 )
 ```
+
+#### interact
+
+When used, will call this function with driver as parameter  and the data of this call return will be added to the response `meta`:
+
+```python
+def interact_on_page(driver):
+  radio_all = driver.find_element(By.CSS_SELECTOR, '.some-class a')
+  ActionChains(driver).move_to_element(radio_all).click(radio_all).perform()
+  WebDriverWait(driver, timeout=30).until_not(lambda d: d.find_element(By.CLASS_NAME, '.loading'))
+  data = driver.execute_script('const data={}; ********; return data;')
+	return data
+
+yield SeleniumRequest(
+    url=url,
+    callback=self.parse_result,
+    interact=interact_on_page
+)
+
+def parse_result(self, response):
+    dynamic_data = response.request.meta['interact_data'] 
+```
+

--- a/scrapy_selenium/http.py
+++ b/scrapy_selenium/http.py
@@ -6,7 +6,7 @@ from scrapy import Request
 class SeleniumRequest(Request):
     """Scrapy ``Request`` subclass providing additional arguments"""
 
-    def __init__(self, wait_time=None, wait_until=None, screenshot=False, script=None, *args, **kwargs):
+    def __init__(self, wait_time=None, wait_until=None, screenshot=False, script=None, interact=None,*args, **kwargs):
         """Initialize a new selenium request
 
         Parameters
@@ -28,5 +28,6 @@ class SeleniumRequest(Request):
         self.wait_until = wait_until
         self.screenshot = screenshot
         self.script = script
+        self.interact = interact
 
         super().__init__(*args, **kwargs)

--- a/scrapy_selenium/middlewares.py
+++ b/scrapy_selenium/middlewares.py
@@ -46,11 +46,6 @@ class SeleniumMiddleware:
         for argument in driver_arguments:
             driver_options.add_argument(argument)
 
-        driver_kwargs = {
-            'executable_path': driver_executable_path,
-            f'{driver_name}_options': driver_options
-        }
-
         # locally installed driver
         if driver_executable_path is not None:
             driver_kwargs = {
@@ -58,6 +53,7 @@ class SeleniumMiddleware:
                 f'{driver_name}_options': driver_options
             }
             self.driver = driver_klass(**driver_kwargs)
+
         # remote driver
         elif command_executor is not None:
             from selenium import webdriver

--- a/scrapy_selenium/middlewares.py
+++ b/scrapy_selenium/middlewares.py
@@ -121,6 +121,9 @@ class SeleniumMiddleware:
         if request.script:
             self.driver.execute_script(request.script)
 
+        if interact_func := request.interact:
+            request.meta['interact_data'] = interact_func(self.driver)
+        
         body = str.encode(self.driver.page_source)
 
         # Expose the driver via the "meta" attribute


### PR DESCRIPTION
When the code is asynchronous, perform action by the driver from response, would cause many conflict.
Add the support for perform actions before return response from middleware.
