### PR TITLE
Fix default value for SELENIUM_DRIVER_ARGUMENTS as empty list

### DIFF
--- a/scrapy_selenium/middlewares.py
+++ b/scrapy_selenium/middlewares.py
@@ -73,7 +73,7 @@ class SeleniumMiddleware:
         driver_executable_path = crawler.settings.get('SELENIUM_DRIVER_EXECUTABLE_PATH')
         browser_executable_path = crawler.settings.get('SELENIUM_BROWSER_EXECUTABLE_PATH')
         command_executor = crawler.settings.get('SELENIUM_COMMAND_EXECUTOR')
-        driver_arguments = crawler.settings.get('SELENIUM_DRIVER_ARGUMENTS')
+        driver_arguments = crawler.settings.getlist('SELENIUM_DRIVER_ARGUMENTS')
 
         if driver_name is None:
             raise NotConfigured('SELENIUM_DRIVER_NAME must be set')


### PR DESCRIPTION
`Settings.get()` default value is `None`. The default value for `SELENIUM_DRIVER_ARGUMENTS` should be an empty list to  support `for` loop.

```python
class SeleniumMiddleware:
    def __init__(self, driver_name, driver_executable_path,
        browser_executable_path, command_executor, driver_arguments):
        ...
        for argument in driver_arguments:
            driver_options.add_argument(argument)
```