### PR TITLE
Updated  'options'  parameter from deprecated values.

### DIFF
--- a/scrapy_selenium/middlewares.py
+++ b/scrapy_selenium/middlewares.py
@@ -55,7 +55,7 @@ class SeleniumMiddleware:
         if driver_executable_path is not None:
             driver_kwargs = {
                 'executable_path': driver_executable_path,
-                f'{driver_name}_options': driver_options
+                'options': driver_options
             }
             self.driver = driver_klass(**driver_kwargs)
         # remote driver


### PR DESCRIPTION
Updated  'options'  parameter:  chrome_ options and firefox_options are deprecated.
Check Selenium documentation
https://www.selenium.dev/documentation/webdriver/getting_started/open_browser/