### PR TITLE
Used options instead of {driver_name}_options

### DIFF
--- a/scrapy_selenium/middlewares.py
+++ b/scrapy_selenium/middlewares.py
@@ -55,7 +55,7 @@ class SeleniumMiddleware:
         if driver_executable_path is not None:
             driver_kwargs = {
                 'executable_path': driver_executable_path,
-                f'{driver_name}_options': driver_options
+                f'options': driver_options
             }
             self.driver = driver_klass(**driver_kwargs)
         # remote driver


### PR DESCRIPTION
Solves the following issue

```
2022-12-16 12:31:36 [twisted] CRITICAL: 
Traceback (most recent call last):
  File "/home/vladimir/.local/lib/python3.10/site-packages/twisted/internet/defer.py", line 1697, in _inlineCallbacks
    result = context.run(gen.send, result)
  File "/home/vladimir/.local/lib/python3.10/site-packages/scrapy/crawler.py", line 116, in crawl
    self.engine = self._create_engine()
  File "/home/vladimir/.local/lib/python3.10/site-packages/scrapy/crawler.py", line 130, in _create_engine
    return ExecutionEngine(self, lambda _: self.stop())
  File "/home/vladimir/.local/lib/python3.10/site-packages/scrapy/core/engine.py", line 83, in __init__
    self.downloader = downloader_cls(crawler)
  File "/home/vladimir/.local/lib/python3.10/site-packages/scrapy/core/downloader/__init__.py", line 83, in __init__
    self.middleware = DownloaderMiddlewareManager.from_crawler(crawler)
  File "/home/vladimir/.local/lib/python3.10/site-packages/scrapy/middleware.py", line 60, in from_crawler
    return cls.from_settings(crawler.settings, crawler)
  File "/home/vladimir/.local/lib/python3.10/site-packages/scrapy/middleware.py", line 42, in from_settings
    mw = create_instance(mwcls, settings, crawler)
  File "/home/vladimir/.local/lib/python3.10/site-packages/scrapy/utils/misc.py", line 167, in create_instance
    instance = objcls.from_crawler(crawler, *args, **kwargs)
  File "/home/vladimir/.local/lib/python3.10/site-packages/scrapy_selenium/middlewares.py", line 62, in from_crawler
    middleware = cls(
  File "/home/vladimir/.local/lib/python3.10/site-packages/scrapy_selenium/middlewares.py", line 44, in __init__
    f'{options}': driver_options
NameError: name 'options' is not defined
```

[[TypeError: WebDriver.__init__() got an unexpected keyword argument 'firefox_options' error using firefox_options as arguments in Selenium Python](https://stackoverflow.com/questions/70326002/typeerror-webdriver-init-got-an-unexpected-keyword-argument-firefox-opti)](https://stackoverflow.com/questions/70326002/typeerror-webdriver-init-got-an-unexpected-keyword-argument-firefox-opti
)

