### PR TITLE
Fix executable_path type error by utilising service when connecting to selenium

### DIFF
--- a/scrapy_selenium/middlewares.py
+++ b/scrapy_selenium/middlewares.py
@@ -46,24 +46,24 @@ class SeleniumMiddleware:
         for argument in driver_arguments:
             driver_options.add_argument(argument)
 
-        driver_kwargs = {
-            'executable_path': driver_executable_path,
-            f'{driver_name}_options': driver_options
-        }
-
         # locally installed driver
         if driver_executable_path is not None:
-            driver_kwargs = {
+            service_module = import_module(f'{webdriver_base_path}.service')
+            service_klass = getattr(service_module, 'Service')
+            service_kwargs = {
                 'executable_path': driver_executable_path,
-                f'{driver_name}_options': driver_options
+            }
+            service = service_klass(**service_kwargs)
+            driver_kwargs = {
+                'service': service,
+                'options': driver_options
             }
             self.driver = driver_klass(**driver_kwargs)
         # remote driver
         elif command_executor is not None:
             from selenium import webdriver
-            capabilities = driver_options.to_capabilities()
             self.driver = webdriver.Remote(command_executor=command_executor,
-                                           desired_capabilities=capabilities)
+                                           options=driver_options)
 
     @classmethod
     def from_crawler(cls, crawler):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = scrapy-selenium
-version = 0.0.7
+version = 0.0.8
 url = https://github.com/clemfromspace/scrapy-selenium
 licence = DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
 description = Scrapy with selenium

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,8 @@
 """This module contains the packaging routine for the pybook package"""
 
 from setuptools import setup, find_packages
-try:
-    from pip.download import PipSession
-    from pip.req import parse_requirements
-except ImportError:
-    # It is quick hack to support pip 10 that has changed its internal
-    # structure of the modules.
-    from pip._internal.download import PipSession
-    from pip._internal.req.req_file import parse_requirements
-
+import pathlib
+import pkg_resources
 
 def get_requirements(source):
     """Get the requirements from the given ``source``
@@ -18,17 +11,17 @@ def get_requirements(source):
     ----------
     source: str
         The filename containing the requirements
-
     """
+    with pathlib.Path(source).open() as requirements_txt:
+        install_req = [
+            str(requirement)
+            for requirement
+            in pkg_resources.parse_requirements(requirements_txt)
+        ]
 
-    install_reqs = parse_requirements(filename=source, session=PipSession())
-
-    return [str(ir.req) for ir in install_reqs]
-
+    return install_req
 
 setup(
     packages=find_packages(),
     install_requires=get_requirements('requirements/requirements.txt')
 )
-
-


### PR DESCRIPTION
1. Fixed the executable_path TypeError https://github.com/clemfromspace/scrapy-selenium/issues/128
2. Fixing remote driver functionality by fixing the deprecated desired_capabilities for options.
3. Removed pip_tools when getting the installation requirements for the build in `setup.py`. Pip keeps updating its package structure and the current implementation breaks  in  versions `pip >= 20` cause of the new package structure 